### PR TITLE
test: add orchestration and analysis coverage (A1-A3)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,6 +287,51 @@ def sample_haplotype_sequences(minimal_config: dict[str, Any]) -> list[tuple[str
 
 
 # ============================================================================
+# Simulation Options Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def mock_simulation_options(tmp_path: Path, temp_config_file: Path):
+    """SimulationOptions with sensible defaults for testing."""
+    from muc_one_up.cli.options import SimulationOptions
+
+    out_dir = tmp_path / "output"
+    out_dir.mkdir(exist_ok=True)
+    return SimulationOptions(
+        config=str(temp_config_file),
+        out_base="test_sim",
+        out_dir=str(out_dir),
+        num_haplotypes=2,
+        seed=42,
+        reference_assembly="hg38",
+        output_structure=False,
+        mutation_name=None,
+        mutation_targets=None,
+        simulate_reads=None,
+        output_orfs=False,
+        orf_min_aa=100,
+        orf_aa_prefix=None,
+        snp_input_file=None,
+        random_snps=False,
+        track_read_source=False,
+    )
+
+
+@pytest.fixture
+def sample_haplotype_results(minimal_config: dict[str, Any]) -> list:
+    """Two HaplotypeResult objects with real assembled sequences."""
+    from muc_one_up.simulate import simulate_from_chains
+    from muc_one_up.type_defs import RepeatUnit
+
+    chains = [
+        [RepeatUnit.from_str(s) for s in ["1", "2", "X", "B", "6", "7", "8", "9"]],
+        [RepeatUnit.from_str(s) for s in ["1", "2", "A", "B", "6p", "7", "8", "9"]],
+    ]
+    return simulate_from_chains(chains, minimal_config)
+
+
+# ============================================================================
 # Mock Fixtures
 # ============================================================================
 

--- a/tests/test_cli_analysis.py
+++ b/tests/test_cli_analysis.py
@@ -1,0 +1,515 @@
+"""Tests for muc_one_up.cli.analysis module.
+
+Covers: _run_toxic_detection, run_orf_prediction, run_read_simulation,
+write_simulation_statistics.
+"""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ============================================================================
+# _run_toxic_detection tests
+# ============================================================================
+
+
+class TestRunToxicDetection:
+    """Tests for the _run_toxic_detection helper."""
+
+    def test_extracts_config_parameters(self, minimal_config):
+        """Custom toxic_protein_detection values are forwarded to scan_orf_fasta."""
+        from muc_one_up.cli.analysis import _run_toxic_detection
+
+        minimal_config["toxic_protein_detection"] = {
+            "consensus_motif": "CUSTOM",
+            "identity_threshold": 0.9,
+            "key_residues": ["A", "B"],
+            "expected_repeat_count": 5,
+            "weights": {"repeat": 0.7, "composition": 0.3},
+            "toxic_cutoff": 0.6,
+        }
+
+        with patch(
+            "muc_one_up.toxic_protein_detector.scan_orf_fasta", return_value={}
+        ) as mock_scan:
+            _run_toxic_detection("/fake/orfs.fa", minimal_config)
+
+        mock_scan.assert_called_once()
+        kwargs = mock_scan.call_args
+        assert kwargs[1]["consensus"] == "CUSTOM"
+        assert kwargs[1]["identity_threshold"] == 0.9
+        assert kwargs[1]["key_residues"] == ["A", "B"]
+        assert kwargs[1]["expected_repeat_count"] == 5
+        assert kwargs[1]["w_repeat"] == 0.7
+        assert kwargs[1]["w_composition"] == 0.3
+        assert kwargs[1]["toxic_detection_cutoff"] == 0.6
+
+    def test_uses_defaults_when_toxic_config_missing(self, minimal_config):
+        """Default detection parameters used when toxic_protein_detection absent."""
+        from muc_one_up.cli.analysis import _run_toxic_detection
+
+        # Ensure no toxic config
+        minimal_config.pop("toxic_protein_detection", None)
+
+        with patch(
+            "muc_one_up.toxic_protein_detector.scan_orf_fasta", return_value={}
+        ) as mock_scan:
+            _run_toxic_detection("/fake/orfs.fa", minimal_config)
+
+        kwargs = mock_scan.call_args[1]
+        assert kwargs["consensus"] == "RCHLGPGHQAGPGLHR"
+        assert kwargs["identity_threshold"] == 0.8
+        assert kwargs["toxic_detection_cutoff"] == 0.5
+
+    def test_uses_correct_assembly_constants(self, minimal_config):
+        """Left and right constants from the correct reference assembly are passed."""
+        from muc_one_up.cli.analysis import _run_toxic_detection
+
+        with patch(
+            "muc_one_up.toxic_protein_detector.scan_orf_fasta", return_value={}
+        ) as mock_scan:
+            _run_toxic_detection("/fake/orfs.fa", minimal_config)
+
+        call_args = mock_scan.call_args
+        expected_left = minimal_config["constants"]["hg38"]["left"]
+        expected_right = minimal_config["constants"]["hg38"]["right"]
+        assert call_args[1]["left_const"] == expected_left
+        assert call_args[1]["right_const"] == expected_right
+
+
+# ============================================================================
+# run_orf_prediction tests
+# ============================================================================
+
+
+class TestRunOrfPrediction:
+    """Tests for run_orf_prediction."""
+
+    def test_skips_when_output_orfs_false(self, mock_simulation_options, minimal_config):
+        """No ORF work when output_orfs is False."""
+        from muc_one_up.cli.analysis import run_orf_prediction
+
+        mock_simulation_options.output_orfs = False
+
+        with patch("muc_one_up.translate.run_orf_finder_in_memory") as mock_orf:
+            run_orf_prediction(
+                mock_simulation_options,
+                minimal_config,
+                str(Path(mock_simulation_options.out_dir)),
+                "test",
+                1,
+                [],
+                None,
+                False,
+            )
+            mock_orf.assert_not_called()
+
+    def test_single_mode_calls_orf_finder_once(
+        self, mock_simulation_options, minimal_config, sample_haplotype_results, tmp_path
+    ):
+        """Single mode: one ORF call, one toxic detection, one stats file."""
+        from muc_one_up.cli.analysis import run_orf_prediction
+
+        mock_simulation_options.output_orfs = True
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        with (
+            patch("muc_one_up.translate.run_orf_finder_in_memory") as mock_orf,
+            patch("muc_one_up.cli.analysis._run_toxic_detection", return_value={"score": 0.5}),
+        ):
+            run_orf_prediction(
+                mock_simulation_options,
+                minimal_config,
+                out_dir,
+                "test",
+                1,
+                sample_haplotype_results,
+                None,
+                False,
+            )
+
+        mock_orf.assert_called_once()
+        # Stats file should have been written
+        stats_files = list(Path(out_dir).glob("*.orf_stats.txt"))
+        assert len(stats_files) == 1
+
+    def test_dual_mode_calls_orf_finder_twice(
+        self, mock_simulation_options, minimal_config, sample_haplotype_results, tmp_path
+    ):
+        """Dual mode: two ORF calls, two toxic detections, two stats files."""
+        from muc_one_up.cli.analysis import run_orf_prediction
+
+        mock_simulation_options.output_orfs = True
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        with (
+            patch("muc_one_up.translate.run_orf_finder_in_memory") as mock_orf,
+            patch("muc_one_up.cli.analysis._run_toxic_detection", return_value={"score": 0.5}),
+        ):
+            run_orf_prediction(
+                mock_simulation_options,
+                minimal_config,
+                out_dir,
+                "test",
+                1,
+                sample_haplotype_results,
+                sample_haplotype_results,
+                True,
+            )
+
+        assert mock_orf.call_count == 2
+        stats_files = list(Path(out_dir).glob("*.orf_stats.txt"))
+        assert len(stats_files) == 2
+
+    def test_orf_failure_raises_file_operation_error(
+        self, mock_simulation_options, minimal_config, sample_haplotype_results, tmp_path
+    ):
+        """FileOperationError raised when ORF finder fails."""
+        from muc_one_up.cli.analysis import run_orf_prediction
+        from muc_one_up.exceptions import FileOperationError
+
+        mock_simulation_options.output_orfs = True
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        with (
+            patch(
+                "muc_one_up.translate.run_orf_finder_in_memory",
+                side_effect=RuntimeError("ORF crash"),
+            ),
+            pytest.raises(FileOperationError, match="ORF finding failed"),
+        ):
+            run_orf_prediction(
+                mock_simulation_options,
+                minimal_config,
+                out_dir,
+                "test",
+                1,
+                sample_haplotype_results,
+                None,
+                False,
+            )
+
+    def test_toxic_import_error_raises_file_operation_error(
+        self, mock_simulation_options, minimal_config, sample_haplotype_results, tmp_path
+    ):
+        """FileOperationError raised when toxic_protein_detector can't be imported."""
+        from muc_one_up.cli.analysis import run_orf_prediction
+        from muc_one_up.exceptions import FileOperationError
+
+        mock_simulation_options.output_orfs = True
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        with (
+            patch("muc_one_up.translate.run_orf_finder_in_memory"),
+            patch(
+                "muc_one_up.cli.analysis._run_toxic_detection",
+                side_effect=ImportError("no module"),
+            ),
+            pytest.raises(FileOperationError, match="import"),
+        ):
+            run_orf_prediction(
+                mock_simulation_options,
+                minimal_config,
+                out_dir,
+                "test",
+                1,
+                sample_haplotype_results,
+                None,
+                False,
+            )
+
+
+# ============================================================================
+# run_read_simulation tests
+# ============================================================================
+
+
+class TestRunReadSimulation:
+    """Tests for run_read_simulation."""
+
+    def test_skips_when_simulate_reads_none(self, mock_simulation_options, minimal_config):
+        """No pipeline call when simulate_reads is None."""
+        from muc_one_up.cli.analysis import run_read_simulation
+
+        mock_simulation_options.simulate_reads = None
+
+        with patch("muc_one_up.read_simulation.simulate_reads") as mock_pipeline:
+            run_read_simulation(mock_simulation_options, minimal_config, ".", "test", 1, False)
+            mock_pipeline.assert_not_called()
+
+    def test_single_mode_calls_pipeline_once(
+        self, mock_simulation_options, minimal_config, tmp_path
+    ):
+        """Single mode: pipeline called once."""
+        from muc_one_up.cli.analysis import run_read_simulation
+
+        mock_simulation_options.simulate_reads = "illumina"
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        with patch("muc_one_up.read_simulation.simulate_reads") as mock_pipeline:
+            run_read_simulation(mock_simulation_options, minimal_config, out_dir, "test", 1, False)
+
+        mock_pipeline.assert_called_once()
+
+    def test_dual_mode_calls_pipeline_twice(
+        self, mock_simulation_options, minimal_config, tmp_path
+    ):
+        """Dual mode: pipeline called for normal and mutated."""
+        from muc_one_up.cli.analysis import run_read_simulation
+
+        mock_simulation_options.simulate_reads = "illumina"
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        with patch("muc_one_up.read_simulation.simulate_reads") as mock_pipeline:
+            run_read_simulation(mock_simulation_options, minimal_config, out_dir, "test", 1, True)
+
+        assert mock_pipeline.call_count == 2
+
+    def test_sets_simulator_in_config(self, mock_simulation_options, minimal_config, tmp_path):
+        """Config read_simulation.simulator is set to the requested type."""
+        from muc_one_up.cli.analysis import run_read_simulation
+
+        mock_simulation_options.simulate_reads = "ont"
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        with patch("muc_one_up.read_simulation.simulate_reads"):
+            run_read_simulation(mock_simulation_options, minimal_config, out_dir, "test", 1, False)
+
+        assert minimal_config["read_simulation"]["simulator"] == "ont"
+
+    def test_failure_raises_read_simulation_error(
+        self, mock_simulation_options, minimal_config, tmp_path
+    ):
+        """ReadSimulationError raised when pipeline fails."""
+        from muc_one_up.cli.analysis import run_read_simulation
+        from muc_one_up.exceptions import ReadSimulationError
+
+        mock_simulation_options.simulate_reads = "illumina"
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        with (
+            patch(
+                "muc_one_up.read_simulation.simulate_reads",
+                side_effect=RuntimeError("pipeline crash"),
+            ),
+            pytest.raises(ReadSimulationError),
+        ):
+            run_read_simulation(mock_simulation_options, minimal_config, out_dir, "test", 1, False)
+
+    def test_dual_mode_passes_source_trackers(
+        self, mock_simulation_options, minimal_config, tmp_path
+    ):
+        """Dual mode forwards source_tracker and source_tracker_mut."""
+        from muc_one_up.cli.analysis import run_read_simulation
+
+        mock_simulation_options.simulate_reads = "illumina"
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        tracker_normal = MagicMock()
+        tracker_mut = MagicMock()
+
+        with patch("muc_one_up.read_simulation.simulate_reads") as mock_pipeline:
+            run_read_simulation(
+                mock_simulation_options,
+                minimal_config,
+                out_dir,
+                "test",
+                1,
+                True,
+                source_tracker=tracker_normal,
+                source_tracker_mut=tracker_mut,
+            )
+
+        # First call (normal) should use tracker_normal
+        assert mock_pipeline.call_args_list[0][1]["source_tracker"] == tracker_normal
+        # Second call (mutated) should use tracker_mut
+        assert mock_pipeline.call_args_list[1][1]["source_tracker"] == tracker_mut
+
+    def test_dual_mode_falls_back_to_source_tracker_when_mut_none(
+        self, mock_simulation_options, minimal_config, tmp_path
+    ):
+        """Dual mode uses source_tracker for mutated when source_tracker_mut is None."""
+        from muc_one_up.cli.analysis import run_read_simulation
+
+        mock_simulation_options.simulate_reads = "illumina"
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        tracker = MagicMock()
+
+        with patch("muc_one_up.read_simulation.simulate_reads") as mock_pipeline:
+            run_read_simulation(
+                mock_simulation_options,
+                minimal_config,
+                out_dir,
+                "test",
+                1,
+                True,
+                source_tracker=tracker,
+                source_tracker_mut=None,
+            )
+
+        # Second call should fall back to tracker
+        assert mock_pipeline.call_args_list[1][1]["source_tracker"] == tracker
+
+
+# ============================================================================
+# write_simulation_statistics tests
+# ============================================================================
+
+
+class TestWriteSimulationStatistics:
+    """Tests for write_simulation_statistics."""
+
+    def test_single_mode_writes_one_file(
+        self, mock_simulation_options, minimal_config, sample_haplotype_results, tmp_path
+    ):
+        """Single mode produces one stats JSON."""
+        from muc_one_up.cli.analysis import write_simulation_statistics
+
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        t_start = time.time()
+        t_end = t_start + 1.0
+
+        write_simulation_statistics(
+            mock_simulation_options,
+            minimal_config,
+            out_dir,
+            "test",
+            1,
+            t_start,
+            t_end,
+            sample_haplotype_results,
+            None,
+            False,
+            None,
+            None,
+            None,
+        )
+
+        stats_files = list(Path(out_dir).glob("*.simulation_stats.json"))
+        assert len(stats_files) == 1
+
+        data = json.loads(stats_files[0].read_text())
+        assert "haplotypes" in data or "runtime_seconds" in data or "provenance" in data
+
+    def test_dual_mode_writes_two_files(
+        self, mock_simulation_options, minimal_config, sample_haplotype_results, tmp_path
+    ):
+        """Dual mode produces normal + mut stats JSONs."""
+        from muc_one_up.cli.analysis import write_simulation_statistics
+
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        t_start = time.time()
+        t_end = t_start + 1.0
+
+        write_simulation_statistics(
+            mock_simulation_options,
+            minimal_config,
+            out_dir,
+            "test",
+            1,
+            t_start,
+            t_end,
+            sample_haplotype_results,
+            sample_haplotype_results,
+            True,
+            ("normal", "dupC"),
+            None,
+            None,
+        )
+
+        stats_files = list(Path(out_dir).glob("*.simulation_stats.json"))
+        assert len(stats_files) == 2
+
+        names = {f.name for f in stats_files}
+        assert any("normal" in n for n in names)
+        assert any("mut" in n for n in names)
+
+    def test_provenance_failure_does_not_crash(
+        self, mock_simulation_options, minimal_config, sample_haplotype_results, tmp_path
+    ):
+        """Graceful degradation when provenance collection fails."""
+        from muc_one_up.cli.analysis import write_simulation_statistics
+
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        t_start = time.time()
+        t_end = t_start + 1.0
+
+        with patch(
+            "muc_one_up.cli.analysis.collect_provenance_metadata",
+            side_effect=RuntimeError("provenance crash"),
+        ):
+            # Should not raise
+            write_simulation_statistics(
+                mock_simulation_options,
+                minimal_config,
+                out_dir,
+                "test",
+                1,
+                t_start,
+                t_end,
+                sample_haplotype_results,
+                None,
+                False,
+                None,
+                None,
+                None,
+            )
+
+        stats_files = list(Path(out_dir).glob("*.simulation_stats.json"))
+        assert len(stats_files) == 1
+
+    def test_single_mode_includes_mutation_info(
+        self, mock_simulation_options, minimal_config, sample_haplotype_results, tmp_path
+    ):
+        """Mutation info included in stats when mutation_name set."""
+        from muc_one_up.cli.analysis import write_simulation_statistics
+
+        mock_simulation_options.mutation_name = "dupC"
+        mock_simulation_options.mutation_targets = ["1,3"]
+        out_dir = str(tmp_path / "out")
+        Path(out_dir).mkdir()
+
+        t_start = time.time()
+        t_end = t_start + 1.0
+
+        write_simulation_statistics(
+            mock_simulation_options,
+            minimal_config,
+            out_dir,
+            "test",
+            1,
+            t_start,
+            t_end,
+            sample_haplotype_results,
+            None,
+            False,
+            None,
+            None,
+            None,
+        )
+
+        stats_files = list(Path(out_dir).glob("*.simulation_stats.json"))
+        data = json.loads(stats_files[0].read_text())
+        # Should contain mutation information somewhere in the stats
+        stats_text = json.dumps(data)
+        assert "dupC" in stats_text or "mutation" in stats_text

--- a/tests/test_cli_orchestration.py
+++ b/tests/test_cli_orchestration.py
@@ -1,0 +1,317 @@
+"""Tests for muc_one_up.cli.orchestration module.
+
+Covers: run_single_simulation_iteration — call ordering, data flow,
+dual mutation mode, source tracker construction.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from muc_one_up.type_defs import HaplotypeResult, MutationTarget, RepeatUnit
+
+# All delegates are module-level imports in orchestration.py, so we patch there.
+PATCH_PREFIX = "muc_one_up.cli.orchestration"
+
+
+def _make_haplotype_results():
+    """Build minimal HaplotypeResult objects for mock returns."""
+    return [
+        HaplotypeResult(
+            sequence="AAAAATTTTT",
+            chain=[RepeatUnit("1"), RepeatUnit("9")],
+        ),
+        HaplotypeResult(
+            sequence="CCCCCGGGGG",
+            chain=[RepeatUnit("1"), RepeatUnit("9")],
+        ),
+    ]
+
+
+@pytest.fixture
+def _mock_delegates():
+    """Patch all 6 delegate functions called by run_single_simulation_iteration.
+
+    Returns a dict of mock objects keyed by function name.
+    """
+    results = _make_haplotype_results()
+
+    with (
+        patch(f"{PATCH_PREFIX}.generate_haplotypes", return_value=results) as m_hap,
+        patch(
+            f"{PATCH_PREFIX}.apply_mutation_pipeline",
+            return_value=(results, None, None, None),
+        ) as m_mut,
+        patch(
+            f"{PATCH_PREFIX}.write_fasta_outputs",
+            return_value=(results, None, None, None),
+        ) as m_fasta,
+        patch(f"{PATCH_PREFIX}.write_mutated_units") as m_units,
+        patch(f"{PATCH_PREFIX}.write_structure_files") as m_struct,
+        patch(f"{PATCH_PREFIX}.run_orf_prediction") as m_orf,
+        patch(f"{PATCH_PREFIX}.run_read_simulation") as m_reads,
+        patch(f"{PATCH_PREFIX}.write_simulation_statistics") as m_stats,
+    ):
+        yield {
+            "generate_haplotypes": m_hap,
+            "apply_mutation_pipeline": m_mut,
+            "write_fasta_outputs": m_fasta,
+            "write_mutated_units": m_units,
+            "write_structure_files": m_struct,
+            "run_orf_prediction": m_orf,
+            "run_read_simulation": m_reads,
+            "write_simulation_statistics": m_stats,
+        }
+
+
+class TestRunSingleSimulationIteration:
+    """Tests for the main orchestration function."""
+
+    def test_calls_all_steps_no_mutation(
+        self, mock_simulation_options, minimal_config, _mock_delegates
+    ):
+        """All delegate functions called in correct order with no mutation."""
+        from muc_one_up.cli.orchestration import run_single_simulation_iteration
+
+        run_single_simulation_iteration(
+            args=mock_simulation_options,
+            config=minimal_config,
+            out_dir=mock_simulation_options.out_dir,
+            out_base="test",
+            sim_index=1,
+            fixed_conf=None,
+            predefined_chains=None,
+            dual_mutation_mode=False,
+            mutation_pair=None,
+            structure_mutation_info=None,
+        )
+
+        # All delegates called exactly once
+        for name, mock in _mock_delegates.items():
+            assert mock.called, f"{name} was not called"
+
+    def test_results_flow_through_pipeline(
+        self, mock_simulation_options, minimal_config, _mock_delegates
+    ):
+        """Return values from each step are passed as arguments to the next."""
+        from muc_one_up.cli.orchestration import run_single_simulation_iteration
+
+        results = _make_haplotype_results()
+        mutated_results = _make_haplotype_results()
+        mutated_units = {1: [(3, "ATCG")]}
+        mutation_positions = [MutationTarget(1, 3)]
+        snp_normal = [None, None]
+        snp_mut = [None, None]
+
+        _mock_delegates["generate_haplotypes"].return_value = results
+        _mock_delegates["apply_mutation_pipeline"].return_value = (
+            results,
+            mutated_results,
+            mutated_units,
+            mutation_positions,
+        )
+        _mock_delegates["write_fasta_outputs"].return_value = (
+            results,
+            mutated_results,
+            snp_normal,
+            snp_mut,
+        )
+
+        mock_simulation_options.mutation_name = "dupC"
+
+        run_single_simulation_iteration(
+            args=mock_simulation_options,
+            config=minimal_config,
+            out_dir=mock_simulation_options.out_dir,
+            out_base="test",
+            sim_index=1,
+            fixed_conf=None,
+            predefined_chains=None,
+            dual_mutation_mode=False,
+            mutation_pair=None,
+            structure_mutation_info=None,
+        )
+
+        # apply_mutation_pipeline receives results from generate_haplotypes
+        mut_call = _mock_delegates["apply_mutation_pipeline"].call_args
+        assert mut_call[0][2] is results  # third positional arg is results
+
+        # write_fasta_outputs receives mutation_positions from apply_mutation_pipeline
+        fasta_call = _mock_delegates["write_fasta_outputs"].call_args
+        assert fasta_call[0][9] is mutation_positions  # 10th positional arg
+
+        # write_structure_files receives mutation_positions
+        struct_call = _mock_delegates["write_structure_files"].call_args
+        assert struct_call[0][8] is mutation_positions
+
+    def test_dual_mutation_mode(self, mock_simulation_options, minimal_config, _mock_delegates):
+        """Dual mode passes mutation_pair through to delegates."""
+        from muc_one_up.cli.orchestration import run_single_simulation_iteration
+
+        mutation_pair = ("normal", "dupC")
+        mock_simulation_options.mutation_name = "normal,dupC"
+
+        run_single_simulation_iteration(
+            args=mock_simulation_options,
+            config=minimal_config,
+            out_dir=mock_simulation_options.out_dir,
+            out_base="test",
+            sim_index=1,
+            fixed_conf=None,
+            predefined_chains=None,
+            dual_mutation_mode=True,
+            mutation_pair=mutation_pair,
+            structure_mutation_info=None,
+        )
+
+        # write_fasta_outputs should receive dual_mutation_mode=True
+        fasta_call = _mock_delegates["write_fasta_outputs"].call_args
+        assert fasta_call[0][7] is True  # dual_mutation_mode
+
+        # write_simulation_statistics should receive mutation_pair
+        stats_call = _mock_delegates["write_simulation_statistics"].call_args
+        assert stats_call[0][10] is mutation_pair
+
+    def test_source_tracker_not_created_when_disabled(
+        self, mock_simulation_options, minimal_config, _mock_delegates
+    ):
+        """No source tracker when track_read_source is False."""
+        from muc_one_up.cli.orchestration import run_single_simulation_iteration
+
+        mock_simulation_options.track_read_source = False
+        mock_simulation_options.simulate_reads = None
+
+        run_single_simulation_iteration(
+            args=mock_simulation_options,
+            config=minimal_config,
+            out_dir=mock_simulation_options.out_dir,
+            out_base="test",
+            sim_index=1,
+            fixed_conf=None,
+            predefined_chains=None,
+            dual_mutation_mode=False,
+            mutation_pair=None,
+            structure_mutation_info=None,
+        )
+
+        reads_call = _mock_delegates["run_read_simulation"].call_args
+        assert reads_call[1]["source_tracker"] is None
+        assert reads_call[1]["source_tracker_mut"] is None
+
+    def test_source_tracker_created_when_enabled(
+        self, mock_simulation_options, minimal_config, _mock_delegates
+    ):
+        """Source tracker constructed when track_read_source=True and simulate_reads set."""
+        from muc_one_up.cli.orchestration import run_single_simulation_iteration
+
+        mock_simulation_options.track_read_source = True
+        mock_simulation_options.simulate_reads = "illumina"
+
+        with patch(
+            "muc_one_up.read_simulator.source_tracking.ReadSourceTracker"
+        ) as mock_tracker_cls:
+            mock_tracker_instance = MagicMock()
+            mock_tracker_cls.return_value = mock_tracker_instance
+
+            run_single_simulation_iteration(
+                args=mock_simulation_options,
+                config=minimal_config,
+                out_dir=mock_simulation_options.out_dir,
+                out_base="test",
+                sim_index=1,
+                fixed_conf=None,
+                predefined_chains=None,
+                dual_mutation_mode=False,
+                mutation_pair=None,
+                structure_mutation_info=None,
+            )
+
+        # ReadSourceTracker was constructed
+        mock_tracker_cls.assert_called_once()
+        # Coordinate map was written
+        mock_tracker_instance.write_coordinate_map.assert_called_once()
+
+        # run_read_simulation got a non-None source_tracker
+        reads_call = _mock_delegates["run_read_simulation"].call_args
+        assert reads_call[1]["source_tracker"] is not None
+
+    def test_source_tracker_dual_mode_creates_two(
+        self, mock_simulation_options, minimal_config, _mock_delegates
+    ):
+        """Dual mode with tracking creates separate normal and mutated trackers."""
+        from muc_one_up.cli.orchestration import run_single_simulation_iteration
+
+        mock_simulation_options.track_read_source = True
+        mock_simulation_options.simulate_reads = "illumina"
+        mock_simulation_options.mutation_name = "normal,dupC"
+
+        mutated_results = _make_haplotype_results()
+        _mock_delegates["apply_mutation_pipeline"].return_value = (
+            _make_haplotype_results(),
+            mutated_results,
+            None,
+            [MutationTarget(1, 1)],
+        )
+        _mock_delegates["write_fasta_outputs"].return_value = (
+            _make_haplotype_results(),
+            mutated_results,
+            None,
+            None,
+        )
+
+        with patch(
+            "muc_one_up.read_simulator.source_tracking.ReadSourceTracker"
+        ) as mock_tracker_cls:
+            mock_instance_1 = MagicMock()
+            mock_instance_2 = MagicMock()
+            mock_tracker_cls.side_effect = [mock_instance_1, mock_instance_2]
+
+            run_single_simulation_iteration(
+                args=mock_simulation_options,
+                config=minimal_config,
+                out_dir=mock_simulation_options.out_dir,
+                out_base="test",
+                sim_index=1,
+                fixed_conf=None,
+                predefined_chains=None,
+                dual_mutation_mode=True,
+                mutation_pair=("normal", "dupC"),
+                structure_mutation_info=None,
+            )
+
+        # Two trackers created
+        assert mock_tracker_cls.call_count == 2
+        # Both wrote coordinate maps
+        mock_instance_1.write_coordinate_map.assert_called_once()
+        mock_instance_2.write_coordinate_map.assert_called_once()
+
+        # run_read_simulation got both trackers
+        reads_call = _mock_delegates["run_read_simulation"].call_args
+        assert reads_call[1]["source_tracker"] is not None
+        assert reads_call[1]["source_tracker_mut"] is not None
+
+    def test_statistics_receive_timing(
+        self, mock_simulation_options, minimal_config, _mock_delegates
+    ):
+        """write_simulation_statistics receives valid start < end timing."""
+        from muc_one_up.cli.orchestration import run_single_simulation_iteration
+
+        run_single_simulation_iteration(
+            args=mock_simulation_options,
+            config=minimal_config,
+            out_dir=mock_simulation_options.out_dir,
+            out_base="test",
+            sim_index=1,
+            fixed_conf=None,
+            predefined_chains=None,
+            dual_mutation_mode=False,
+            mutation_pair=None,
+            structure_mutation_info=None,
+        )
+
+        stats_call = _mock_delegates["write_simulation_statistics"].call_args
+        iteration_start = stats_call[0][5]
+        iteration_end = stats_call[0][6]
+        assert isinstance(iteration_start, float)
+        assert isinstance(iteration_end, float)
+        assert iteration_start <= iteration_end


### PR DESCRIPTION
## Summary
- Add 26 new tests covering the two lowest-coverage integration paths
- `tests/test_cli_analysis.py` (19 tests): toxic detection, ORF prediction, read simulation, statistics
- `tests/test_cli_orchestration.py` (7 tests): call ordering, data flow, dual mode, source trackers
- Shared fixtures added to conftest.py: `mock_simulation_options`, `sample_haplotype_results`

Coverage: 84% -> 87%, test count: 1199 -> 1225.

## Test plan
- [ ] CI passes across Python 3.10-3.12
- [ ] Coverage stays above 70% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)