### PR TITLE
refactor: extract ReadSourceTracker.from_simulation_results() factory

### DIFF
--- a/muc_one_up/cli/orchestration.py
+++ b/muc_one_up/cli/orchestration.py
@@ -137,72 +137,28 @@ def run_single_simulation_iteration(
 
         from ..read_simulator.source_tracking import ReadSourceTracker
 
-        # Build repeat chains dict (1-based haplotype keys) using typed chains
-        repeat_chains = {}
-        for i, hr in enumerate(results):
-            repeat_chains[i + 1] = hr.chain
-
-        # Get left constant length from config
         ref_assembly = getattr(args, "reference_assembly", None) or config.get(
             "reference_assembly", "hg38"
         )
-        left_const = config.get("constants", {}).get(ref_assembly, {}).get("left", "")
-        left_const_len = len(left_const)
-
-        # Get repeats dict
-        repeats_dict = config.get("repeats", {})
-
-        # Get mutation info
         mutation_name_str = getattr(args, "mutation_name", None)
-        mut_positions: list[tuple[int, int]] = []
-        mut_name = None
-        if mutation_positions:
-            mut_positions = [(mt.haplotype_index, mt.repeat_index) for mt in mutation_positions]
-            if mutation_name_str and mutation_name_str != "normal":
-                parts = mutation_name_str.split(",")
-                for p in parts:
-                    if p != "normal":
-                        mut_name = p
-                        break
-
-        # Get SNP info (0-based haplotype indices)
-        snp_info_dict = {}
-        if applied_snp_info_normal:
-            for i, snp_list in enumerate(applied_snp_info_normal):
-                if snp_list:
-                    snp_info_dict[i] = snp_list
 
         if dual_mutation_mode:
-            # Build separate trackers: normal (no mutation) and mutated (with mutation)
-            source_tracker = ReadSourceTracker(
-                repeat_chains=repeat_chains,
-                repeats_dict=repeats_dict,
-                left_const_len=left_const_len,
-                mutation_positions=[],
-                mutation_name=None,
-                snp_info=snp_info_dict if snp_info_dict else None,
+            # Normal tracker: no mutations
+            source_tracker = ReadSourceTracker.from_simulation_results(
+                results=results,
+                config=config,
+                applied_snp_info=applied_snp_info_normal,
+                reference_assembly=ref_assembly,
             )
 
-            # Build mutated chains from mutated_results
-            mut_chains = {}
-            if mutated_results:
-                for i, hr in enumerate(mutated_results):
-                    mut_chains[i + 1] = hr.chain
-
-            # Get mutated SNP info
-            mut_snp_info_dict: dict[int, list[dict[str, object]]] = {}
-            if applied_snp_info_mut:
-                for i, snp_list in enumerate(applied_snp_info_mut):
-                    if snp_list:
-                        mut_snp_info_dict[i] = snp_list
-
-            source_tracker_mut = ReadSourceTracker(
-                repeat_chains=mut_chains if mut_chains else repeat_chains,
-                repeats_dict=repeats_dict,
-                left_const_len=left_const_len,
-                mutation_positions=mut_positions,
-                mutation_name=mut_name,
-                snp_info=mut_snp_info_dict if mut_snp_info_dict else None,
+            # Mutated tracker: with mutations, using mutated chains
+            source_tracker_mut = ReadSourceTracker.from_simulation_results(
+                results=mutated_results if mutated_results else results,
+                config=config,
+                mutation_positions=mutation_positions,
+                mutation_name=mutation_name_str,
+                applied_snp_info=applied_snp_info_mut,
+                reference_assembly=ref_assembly,
             )
 
             # Write coordinate maps for both variants
@@ -218,13 +174,13 @@ def run_single_simulation_iteration(
             source_tracker_mut.write_coordinate_map(mut_coord_path)
             logging.info("Mutated repeat coordinate map written: %s", mut_coord_path)
         else:
-            source_tracker = ReadSourceTracker(
-                repeat_chains=repeat_chains,
-                repeats_dict=repeats_dict,
-                left_const_len=left_const_len,
-                mutation_positions=mut_positions,
-                mutation_name=mut_name,
-                snp_info=snp_info_dict if snp_info_dict else None,
+            source_tracker = ReadSourceTracker.from_simulation_results(
+                results=results,
+                config=config,
+                mutation_positions=mutation_positions,
+                mutation_name=mutation_name_str,
+                applied_snp_info=applied_snp_info_normal,
+                reference_assembly=ref_assembly,
             )
 
             coord_map_path = str(

--- a/muc_one_up/read_simulator/source_tracking.py
+++ b/muc_one_up/read_simulator/source_tracking.py
@@ -293,6 +293,72 @@ class ReadSourceTracker:
                 snp_info=hap_snps,
             )
 
+    @classmethod
+    def from_simulation_results(
+        cls,
+        results: list,
+        config: dict,
+        mutation_positions: list | None = None,
+        mutation_name: str | None = None,
+        applied_snp_info: list | None = None,
+        reference_assembly: str | None = None,
+    ) -> ReadSourceTracker:
+        """Build a tracker from simulation results and config.
+
+        Extracts repeat chains, constants, and SNP info from simulation
+        outputs so callers don't need to reshape the data themselves.
+
+        Args:
+            results: List of HaplotypeResult objects.
+            config: Configuration dict with 'repeats', 'constants', 'reference_assembly'.
+            mutation_positions: List of MutationTarget objects (or None).
+            mutation_name: Mutation name string (e.g. "dupC"), or None.
+            applied_snp_info: List of SNP info lists, indexed by haplotype (0-based).
+            reference_assembly: Override for reference assembly (defaults to config value).
+
+        Returns:
+            Configured ReadSourceTracker instance.
+        """
+        # Build repeat chains dict (1-based haplotype keys)
+        repeat_chains: dict[int, list[RepeatUnit]] = {}
+        for i, hr in enumerate(results):
+            repeat_chains[i + 1] = hr.chain
+
+        # Get left constant length
+        ref_assembly = reference_assembly or config.get("reference_assembly", "hg38")
+        left_const = config.get("constants", {}).get(ref_assembly, {}).get("left", "")
+
+        # Get repeats dict
+        repeats_dict = config.get("repeats", {})
+
+        # Convert MutationTarget objects to tuples
+        mut_positions: list[tuple[int, int]] = []
+        mut_name: str | None = None
+        if mutation_positions:
+            mut_positions = [(mt.haplotype_index, mt.repeat_index) for mt in mutation_positions]
+            if mutation_name and mutation_name != "normal":
+                # Extract non-"normal" mutation name from comma-separated string
+                for part in mutation_name.split(","):
+                    if part != "normal":
+                        mut_name = part
+                        break
+
+        # Build SNP info dict (0-based haplotype indices)
+        snp_info_dict: dict[int, list[dict[str, object]]] = {}
+        if applied_snp_info:
+            for i, snp_list in enumerate(applied_snp_info):
+                if snp_list:
+                    snp_info_dict[i] = snp_list
+
+        return cls(
+            repeat_chains=repeat_chains,
+            repeats_dict=repeats_dict,
+            left_const_len=len(left_const),
+            mutation_positions=mut_positions,
+            mutation_name=mut_name,
+            snp_info=snp_info_dict if snp_info_dict else None,
+        )
+
     def annotate_reads(self, origins: Iterable[ReadOrigin]) -> Iterator[AnnotatedRead]:
         """Annotate reads with VNTR overlap, repeat units, and mutation status.
 

--- a/tests/test_cli_orchestration.py
+++ b/tests/test_cli_orchestration.py
@@ -207,12 +207,11 @@ class TestRunSingleSimulationIteration:
         mock_simulation_options.track_read_source = True
         mock_simulation_options.simulate_reads = "illumina"
 
+        mock_tracker_instance = MagicMock()
         with patch(
-            "muc_one_up.read_simulator.source_tracking.ReadSourceTracker"
-        ) as mock_tracker_cls:
-            mock_tracker_instance = MagicMock()
-            mock_tracker_cls.return_value = mock_tracker_instance
-
+            "muc_one_up.read_simulator.source_tracking.ReadSourceTracker.from_simulation_results",
+            return_value=mock_tracker_instance,
+        ) as mock_factory:
             run_single_simulation_iteration(
                 args=mock_simulation_options,
                 config=minimal_config,
@@ -226,8 +225,8 @@ class TestRunSingleSimulationIteration:
                 structure_mutation_info=None,
             )
 
-        # ReadSourceTracker was constructed
-        mock_tracker_cls.assert_called_once()
+        # Factory was called
+        mock_factory.assert_called_once()
         # Coordinate map was written
         mock_tracker_instance.write_coordinate_map.assert_called_once()
 
@@ -259,13 +258,12 @@ class TestRunSingleSimulationIteration:
             None,
         )
 
+        mock_instance_1 = MagicMock()
+        mock_instance_2 = MagicMock()
         with patch(
-            "muc_one_up.read_simulator.source_tracking.ReadSourceTracker"
-        ) as mock_tracker_cls:
-            mock_instance_1 = MagicMock()
-            mock_instance_2 = MagicMock()
-            mock_tracker_cls.side_effect = [mock_instance_1, mock_instance_2]
-
+            "muc_one_up.read_simulator.source_tracking.ReadSourceTracker.from_simulation_results",
+            side_effect=[mock_instance_1, mock_instance_2],
+        ) as mock_factory:
             run_single_simulation_iteration(
                 args=mock_simulation_options,
                 config=minimal_config,
@@ -279,8 +277,8 @@ class TestRunSingleSimulationIteration:
                 structure_mutation_info=None,
             )
 
-        # Two trackers created
-        assert mock_tracker_cls.call_count == 2
+        # Two trackers created via factory
+        assert mock_factory.call_count == 2
         # Both wrote coordinate maps
         mock_instance_1.write_coordinate_map.assert_called_once()
         mock_instance_2.write_coordinate_map.assert_called_once()


### PR DESCRIPTION
## Summary
- Move ~100 lines of source tracker data reshaping from `orchestration.py` into `ReadSourceTracker.from_simulation_results()` classmethod
- Orchestration now calls the factory instead of manually building repeat chains, extracting constants, converting mutation targets, and assembling SNP info dicts
- Addresses review finding D1-D2 (orchestration carries domain logic)

## Test plan
- [ ] CI passes (ruff, mypy, pytest across 3.10-3.12)
- [ ] Existing source tracker tests still pass
- [ ] Orchestration tests updated to mock factory instead of constructor

🤖 Generated with [Claude Code](https://claude.com/claude-code)