### PR TITLE
fix: targeted CLI UX polish

### DIFF
--- a/muc_one_up/cli/click_main.py
+++ b/muc_one_up/cli/click_main.py
@@ -31,6 +31,7 @@ from ._common import (
     "--log-level",
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NONE"]),
     default="INFO",
+    show_default=True,
     help="Set logging level.",
 )
 @click.option(

--- a/muc_one_up/cli/commands/analyze.py
+++ b/muc_one_up/cli/commands/analyze.py
@@ -23,8 +23,9 @@ def analyze():
     """Analysis utilities.
 
     \b
-    Single Responsibility: Analyze ANY FASTA file.
+    Analyze ANY FASTA file.
     Works with MucOneUp outputs or external sequences.
+    Requires --config at the top level.
     """
 
 

--- a/muc_one_up/cli/commands/reads.py
+++ b/muc_one_up/cli/commands/reads.py
@@ -113,8 +113,9 @@ def reads():
     """Read simulation utilities.
 
     \b
-    Single Responsibility: Simulate reads from ANY FASTA file.
+    Simulate reads from ANY FASTA file.
     Works with MucOneUp outputs or external sequences.
+    Requires --config at the top level.
     """
 
 
@@ -345,7 +346,7 @@ def ont(ctx, input_fastas, out_dir, out_base, coverage, min_read_length, seed, t
     "--min-rq",
     type=float,
     default=None,
-    help="Minimum predicted accuracy for HiFi reads (0.0-1.0, overrides config if provided). 0.99 = Q20 (standard HiFi).",
+    help="Minimum predicted read quality (RQ) score (0.0-1.0). 0.99=Q20 (standard HiFi), 0.999=Q30.",
 )
 @click.option(
     "--model-type",

--- a/muc_one_up/cli/commands/simulate.py
+++ b/muc_one_up/cli/commands/simulate.py
@@ -74,7 +74,7 @@ from ..orchestration import run_single_simulation_iteration
 # Mutation Options
 @click.option(
     "--mutation-name",
-    help="Mutation name. Use 'normal,mutation' for dual simulation.",
+    help="Mutation name (e.g., 'dupC'). Use 'normal,dupC' for dual output (normal + mutated).",
 )
 @click.option(
     "--mutation-targets",


### PR DESCRIPTION
## Summary
- Add `show_default=True` to `--log-level` (the concrete default miss)
- Clarify `--mutation-name` help: explain `'normal,dupC'` dual output format
- Explain RQ score in `--min-rq`: `0.99=Q20, 0.999=Q30`
- Add "Requires --config" note to `reads` and `analyze` group help text
- Remove "Single Responsibility" language from user-facing help

Phase 4 of remaining work plan.

## Test plan
- [ ] CI passes
- [ ] `muconeup --help`, `muconeup reads --help`, `muconeup analyze --help` show updated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)