### PR TITLE
refactor: add section-level TypedDicts for config typing

### DIFF
--- a/muc_one_up/mutate.py
+++ b/muc_one_up/mutate.py
@@ -45,6 +45,7 @@ import random as _random_module
 
 from .assembly import assemble_sequence
 from .type_defs import (
+    AssemblyConstants,
     ConfigDict,
     DNASequence,
     HaplotypeResult,
@@ -267,9 +268,10 @@ def apply_changes_to_repeat(
         - replace: Replace bases from start to end with sequence
         - delete_insert: Delete between boundaries, insert at boundary
     """
-    repeats_dict = config["repeats"]
+    repeats_dict: dict[str, str] = config["repeats"]
     reference_assembly = config.get("reference_assembly", "hg38")
-    left_const_len = len(config["constants"][reference_assembly]["left"])
+    assembly_const: AssemblyConstants = config["constants"][reference_assembly]
+    left_const_len = len(assembly_const["left"])
 
     offset = left_const_len
     for i in range(repeat_index):

--- a/muc_one_up/simulate.py
+++ b/muc_one_up/simulate.py
@@ -40,6 +40,7 @@ import random as _random_module
 from .assembly import assemble_sequence
 from .distribution import sample_repeat_count
 from .type_defs import (
+    AssemblyConstants,
     ConfigDict,
     DNASequence,
     HaplotypeResult,
@@ -241,10 +242,11 @@ def simulate_single_haplotype(
     _rng = rng if rng is not None else _random_module
 
     reference_assembly = config.get("reference_assembly", "hg38")
-    left_const = config["constants"][reference_assembly]["left"]
-    right_const = config["constants"][reference_assembly]["right"]
-    probabilities = config["probabilities"]
-    repeats_dict = config["repeats"]
+    assembly_const: AssemblyConstants = config["constants"][reference_assembly]
+    left_const = assembly_const["left"]
+    right_const = assembly_const["right"]
+    probabilities: ProbabilitiesDict = config["probabilities"]
+    repeats_dict: dict[str, str] = config["repeats"]
 
     assembled_seq = left_const
     repeat_chain: list[RepeatUnit] = []

--- a/muc_one_up/type_defs.py
+++ b/muc_one_up/type_defs.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, TypedDict
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,12 +110,106 @@ class MutationTarget:
 # Legacy type alias — used by thin wrappers accepting raw string chains
 RepeatChain = list[str]
 
-# Configuration types
+# ---------------------------------------------------------------------------
+# Typed config sections (TypedDict — still plain dicts at runtime)
+# ---------------------------------------------------------------------------
+
+
+class LengthModelConfig(TypedDict):
+    """Length model configuration section."""
+
+    distribution: str
+    min_repeats: int
+    max_repeats: int
+    mean_repeats: int
+    median_repeats: int
+
+
+class AssemblyConstants(TypedDict, total=False):
+    """Constants for a single reference assembly (hg19/hg38)."""
+
+    left: str
+    right: str
+    vntr_region: str
+    vntr_start: int
+    vntr_end: int
+
+
+class MutationChangeConfig(TypedDict, total=False):
+    """A single mutation change operation."""
+
+    type: str
+    start: int
+    end: int
+    sequence: str
+
+
+class MutationConfig(TypedDict, total=False):
+    """A single named mutation definition."""
+
+    allowed_repeats: list[str]
+    strict_mode: bool
+    type: str
+    citation: str
+    changes: list[MutationChangeConfig]
+
+
+class ReadSimulationConfig(TypedDict, total=False):
+    """Read simulation configuration section."""
+
+    simulator: str
+    reseq_model: str
+    sample_bam: str
+    sample_bam_hg19: str
+    sample_bam_hg38: str
+    human_reference: str
+    read_number: int
+    fragment_size: int
+    fragment_sd: int
+    min_fragment: int
+    threads: int
+    coverage: int
+    seed: int | None
+    aligner: str
+    keep_intermediate_files: bool
+
+
+class NanosimConfig(TypedDict, total=False):
+    """NanoSim (ONT) simulation parameters."""
+
+    training_data_path: str
+    coverage: float
+    num_threads: int | None
+    min_read_length: int | None
+    max_read_length: int | None
+    seed: int | None
+    min_len: int
+
+
+class PacbioConfig(TypedDict, total=False):
+    """PacBio HiFi simulation parameters."""
+
+    model_type: str
+    model_file: str
+    coverage: float
+    pass_num: int
+    min_passes: int
+    min_rq: float
+    threads: int
+    seed: int | None
+    pbsim3_cmd: str
+    ccs_cmd: str
+
+
+# ---------------------------------------------------------------------------
+# Legacy aliases (kept for backward compatibility)
+# ---------------------------------------------------------------------------
+
 ConfigDict = dict[str, Any]
 RepeatsDict = dict[str, str]
 ProbabilitiesDict = dict[str, dict[str, float]]
 ConstantsDict = dict[str, dict[str, str]]
-LengthModelDict = dict[str, Any]
+LengthModelDict = LengthModelConfig  # Now an alias for the TypedDict
 
 # Mutation types
 MutationName = str


### PR DESCRIPTION
## Summary
- Define 7 TypedDicts for config sections: `LengthModelConfig`, `AssemblyConstants`, `MutationChangeConfig`, `MutationConfig`, `ReadSimulationConfig`, `NanosimConfig`, `PacbioConfig`
- These are plain dicts at runtime (no `from_dict()` bridge) — existing code that mutates config sections keeps working
- `LengthModelDict` is now an alias for `LengthModelConfig` (seamless)
- Apply typed local annotations in `simulate.py` and `mutate.py` where sections are extracted
- Incremental approach: callers can adopt section types gradually

Phase 5 of remaining work plan.

## Test plan
- [ ] CI passes (ruff, mypy, pytest)
- [ ] No runtime behavior changes (TypedDicts are structural, not nominal)
- [ ] mypy still at 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)