### PR TITLE
fix: two-step VNTR downsampling to match real exome coverage profiles

### DIFF
--- a/.planning/reports/2026-04-06-vntr-downsampling-validation.md
+++ b/.planning/reports/2026-04-06-vntr-downsampling-validation.md
@@ -18,8 +18,8 @@ All coverage measurements use `samtools depth -a` (includes zero-coverage positi
 
 - VNTR region: chr1:155,188,487-155,192,239 (hg38, 3,753 bp)
 - Non-VNTR BED: `data/bed/twist_v2_muc1_no_vntr_targets.bed` (765 bp, 7 Twist probe regions)
-- Real exome BAMs: `/home/bernt-popp/development/vntyper-analyses/results/screening/Bernt/data/cerkid-exome-chr1/`
-- Simulated BAMs: `/tmp/sim_batch/len_{30..90}/sim_{len}.001.simulated_reads_downsampled.bam`
+- Real exome BAMs: CerKiD Berlin cohort, pre-sliced chr1 MUC1 region extracts (vntyper-analyses)
+- Simulated BAMs: 50 MucOneUp runs with VNTR lengths 30-90
 
 ---
 
@@ -140,7 +140,7 @@ R = Real exomes (n=1,043), S = Simulated (n=50)
 
 ### Simulation outputs
 
-Each simulation is in `/tmp/sim_batch/len_{N}/` containing:
+Each simulation output directory (`len_{N}/`) contains:
 
 ```
 sim_{N}.001.simulated.fa                              # Input haplotype FASTA
@@ -159,12 +159,11 @@ Total: 50 simulations, 658 MB disk.
 
 ### Real exome BAMs
 
-`/home/bernt-popp/development/vntyper-analyses/results/screening/Bernt/data/cerkid-exome-chr1/*.chr1_155184000_155194000.bam`
+CerKiD Berlin cohort, pre-sliced to chr1:155184000-155194000 (from vntyper-analyses screening data).
 
 ### Raw data files
 
-- `/tmp/real_exome_stats.json` -- per-sample metrics for all 1,043 real exomes
-- `/tmp/sim_batch_results.json` -- per-simulation metrics for all 50 simulations
+Per-sample and per-simulation metrics were saved as JSON during analysis (not committed to repo).
 
 ---
 

--- a/muc_one_up/read_simulator/stages/alignment.py
+++ b/muc_one_up/read_simulator/stages/alignment.py
@@ -269,7 +269,12 @@ def align_and_refine(
             # Use the empirical VNTR:non-VNTR ratio from real data to set VNTR target.
             # Default 1.4 derived from median of 20 CerKiD Berlin Twist v2 exomes
             # (VNTR mean / non-VNTR BED mean, samtools depth -a).
-            vntr_to_flanking_ratio: float = rs_config.get("vntr_to_flanking_ratio", 1.4)
+            raw_ratio = rs_config.get("vntr_to_flanking_ratio", 1.4)
+            vntr_to_flanking_ratio = float(raw_ratio)
+            if vntr_to_flanking_ratio <= 0:
+                raise ConfigurationError(
+                    f"vntr_to_flanking_ratio must be > 0, got {vntr_to_flanking_ratio}"
+                )
             vntr_target = actual_non_vntr * vntr_to_flanking_ratio
 
             if vntr_cov > vntr_target and actual_non_vntr > 0:

--- a/muc_one_up/read_simulator/wrappers/samtools_coverage.py
+++ b/muc_one_up/read_simulator/wrappers/samtools_coverage.py
@@ -186,12 +186,14 @@ def downsample_bam(
     # Format the fraction string for samtools view -s option (seed.fraction)
     fraction_str = f"{seed}.{int(fraction * 10000):04d}"
 
-    # Create a temporary BED file for the target region
+    # Create a temporary BED file for the target region.
+    # Region string is 1-based inclusive (samtools format); BED is 0-based half-open.
     region_bed = output_bam.replace(".bam", "_region.bed")
     chrom, coords = region.split(":")
     start, end = coords.split("-")
+    bed_start = int(start) - 1  # Convert 1-based inclusive → 0-based
     with Path(region_bed).open("w") as f:
-        f.write(f"{chrom}\t{start}\t{end}\n")
+        f.write(f"{chrom}\t{bed_start}\t{end}\n")
 
     # Two-pass approach: extract non-region reads (full) then region reads (downsampled).
     # Cannot use -L/-U/-s together because -U captures reads failing ANY filter,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "muc_one_up"
-version = "0.44.0"
+version = "0.44.1"
 description = "MucOneUp: a tool to simulate MUC1 VNTR diploid references"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/read_simulator/test_alignment_stage.py
+++ b/tests/read_simulator/test_alignment_stage.py
@@ -360,6 +360,32 @@ class TestAlignAndRefine:
                 assembly_ctx=assembly_ctx_no_vntr,
             )
 
+    def test_raises_configuration_error_vntr_mode_no_sample_target_bed(
+        self, mocker, tmp_path, tools, assembly_ctx
+    ):
+        """ConfigurationError raised when vntr mode but no sample_target_bed."""
+        mocker.patch(f"{MODULE}.align_reads")
+
+        rs_config_ds = {
+            "threads": 4,
+            "vntr_capture_efficiency": {"enabled": False},
+            "coverage": 100,
+            "downsample_mode": "vntr",
+            # no sample_target_bed
+        }
+
+        with pytest.raises(ConfigurationError, match=r"sample_target_bed"):
+            align_and_refine(
+                tools=tools,
+                rs_config=rs_config_ds,
+                r1=str(tmp_path / "r1.fastq.gz"),
+                r2=str(tmp_path / "r2.fastq.gz"),
+                human_ref="/ref/hg38.fa",
+                output_dir=tmp_path,
+                output_base="test_sample",
+                assembly_ctx=assembly_ctx,
+            )
+
     def test_raises_configuration_error_non_vntr_mode_no_bed(
         self, mocker, tmp_path, tools, assembly_ctx
     ):

--- a/tests/read_simulator/test_samtools_wrapper.py
+++ b/tests/read_simulator/test_samtools_wrapper.py
@@ -326,6 +326,105 @@ class TestDownsampleBAM:
         assert view_cmd[at_index + 1] == "8"
 
 
+class TestDownsampleBamRegion:
+    """Test downsample_bam region-specific two-pass downsampling."""
+
+    def test_two_pass_approach_constructs_correct_commands(self, mocker, tmp_path):
+        """Test that downsample_bam uses -L/-U pass then -L/-s pass."""
+        from muc_one_up.read_simulator.wrappers.samtools_coverage import downsample_bam
+
+        input_bam = tmp_path / "input.bam"
+        output_bam = tmp_path / "output.bam"
+        input_bam.write_bytes(b"BAM_DATA")
+
+        commands_called = []
+
+        def mock_popen_side_effect(cmd, **kwargs):
+            commands_called.append(cmd)
+            mock_proc = Mock()
+            mock_proc.returncode = 0
+            mock_proc.stdout = Mock()
+            mock_proc.stderr = Mock()
+            mock_proc.stdout.readline = Mock(return_value=b"")
+            mock_proc.stderr.readline = Mock(return_value=b"")
+            mock_proc.wait = Mock(return_value=0)
+            mock_proc.pid = 12345
+
+            # Create expected intermediate/output files
+            for c in cmd:
+                if str(c).endswith(".bam") and cmd[0] != "samtools":
+                    pass
+            # Create region_only, other_regions, and output BAMs
+            region_only = str(output_bam).replace(".bam", "_region_only.bam")
+            other_regions = str(output_bam).replace(".bam", "_other_regions.bam")
+            Path(region_only).write_bytes(b"REGION")
+            Path(other_regions).write_bytes(b"OTHER")
+            output_bam.write_bytes(b"MERGED")
+            Path(str(output_bam) + ".bai").write_bytes(b"INDEX")
+
+            return mock_proc
+
+        mocker.patch("subprocess.Popen", side_effect=mock_popen_side_effect)
+
+        downsample_bam("samtools", str(input_bam), str(output_bam), "chr1:100-200", 0.5, 42, 4)
+
+        # Should have 4 commands: pass1 (view -L -U), pass2 (view -s -L), merge, index
+        assert len(commands_called) == 4
+
+        # Pass 1: -L and -U present, no -s
+        pass1 = commands_called[0]
+        assert "-L" in pass1
+        assert "-U" in pass1
+        assert "-s" not in pass1
+
+        # Pass 2: -s and -L present, no -U
+        pass2 = commands_called[1]
+        assert "-s" in pass2
+        assert "-L" in pass2
+        assert "-U" not in pass2
+        s_idx = pass2.index("-s")
+        assert pass2[s_idx + 1] == "42.5000"
+
+        # BED file created and cleaned up (verified in test_creates_and_cleans_up_temp_files)
+
+    def test_creates_and_cleans_up_temp_files(self, mocker, tmp_path):
+        """Test that BED and intermediate BAMs are cleaned up."""
+        from muc_one_up.read_simulator.wrappers.samtools_coverage import downsample_bam
+
+        input_bam = tmp_path / "input.bam"
+        output_bam = tmp_path / "output.bam"
+        input_bam.write_bytes(b"BAM_DATA")
+
+        def mock_popen_side_effect(cmd, **kwargs):
+            mock_proc = Mock()
+            mock_proc.returncode = 0
+            mock_proc.stdout = Mock()
+            mock_proc.stderr = Mock()
+            mock_proc.stdout.readline = Mock(return_value=b"")
+            mock_proc.stderr.readline = Mock(return_value=b"")
+            mock_proc.wait = Mock(return_value=0)
+            mock_proc.pid = 12345
+
+            # Create all intermediate files that the function expects
+            for suffix in ["_region_only.bam", "_other_regions.bam"]:
+                Path(str(output_bam).replace(".bam", suffix)).write_bytes(b"DATA")
+            output_bam.write_bytes(b"MERGED")
+            Path(str(output_bam) + ".bai").write_bytes(b"INDEX")
+
+            return mock_proc
+
+        mocker.patch("subprocess.Popen", side_effect=mock_popen_side_effect)
+
+        downsample_bam("samtools", str(input_bam), str(output_bam), "chr1:100-200", 0.3, 42, 4)
+
+        # Intermediate files should be cleaned up
+        assert not Path(str(output_bam).replace(".bam", "_region_only.bam")).exists()
+        assert not Path(str(output_bam).replace(".bam", "_other_regions.bam")).exists()
+        assert not Path(str(output_bam).replace(".bam", "_region.bed")).exists()
+        # Output should exist
+        assert output_bam.exists()
+
+
 class TestConvertSamToBam:
     """Test convert_sam_to_bam SAM→BAM conversion."""
 


### PR DESCRIPTION
## Summary

Fixes three bugs in `downsample_mode: "vntr"` that made it produce completely unrealistic coverage profiles:

1. **`^region` syntax broken** -- `downsample_bam()` used `samtools view ^chr1:...` to extract non-VNTR reads, which silently returns zero reads. All flanking reads were dropped. Replaced with two-pass BED-based approach (`-L`/`-U` for extraction, `-L`/`-s` for downsampling).

2. **Single-step VNTR-only downsampling** -- Downsampled only the VNTR region, leaving flanking at 700x+ while reducing VNTR to 150x. Produced inverted VNTR:flanking ratio (0.5x vs real 1.4x). Replaced with two-step:
   - Step 1: downsample entire BAM so non-VNTR BED = target coverage
   - Step 2: downsample VNTR region to match empirical ratio (default 1.4, configurable via `vntr_to_flanking_ratio`)

3. **Same seed for both steps** -- samtools `-s` uses hash-based subsampling, so reads surviving step 1's lower fraction always survive step 2 at the same seed. Step 2 now uses seed+1.

## Validation (1,043 real exomes vs 50 simulations)

| Metric | Real (median) | Simulated (median) | Sim/Real | Verdict |
|--------|--------------|-------------------|----------|---------|
| VNTR mean | 169x | 204x | 1.21 | GOOD |
| VNTR median | 106x | 77x | 0.73 | GOOD |
| Non-VNTR BED | 107x | 150x | 1.40 | GOOD |
| VNTR:BED ratio | 1.6x | 1.4x | 0.87 | GOOD |
| Total reads | 29,784 | 8,827 | 0.30 | POOR* |
| VNTR % uncov | 9.9% | 24.4% | 2.48 | POOR* |

*POOR metrics are pre-existing read generation characteristics, not downsampling issues.

Full validation report: `.planning/reports/2026-04-06-vntr-downsampling-validation.md`

## Test plan

- [x] 1,423 tests pass (89% coverage)
- [x] ruff clean
- [x] mypy clean
- [x] 50 simulations (VNTR lengths 30-90) validated against 1,043 real exomes
- [ ] CI passes across Python 3.10-3.12

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)