### PR TITLE
fix: lower amplicon product range minimum from 1500bp to 500bp

### DIFF
--- a/config.json
+++ b/config.json
@@ -534,7 +534,7 @@
     "forward_primer": "GGAGAAAAGGAGACTTCGGCTACCCAG",
     "reverse_primer": "GCCGTTGTGCACCAGAGTAGAAGCTGA",
     "primer_source": "Wenzel et al. 2018 (PMID: 29520014)",
-    "expected_product_range": [1500, 15000],
+    "expected_product_range": [500, 15000],
     "pcr_bias": {
       "preset": "default"
     }

--- a/docs/guides/amplicon-simulation.md
+++ b/docs/guides/amplicon-simulation.md
@@ -219,7 +219,7 @@ Amplicon boundaries are defined by primer binding sites in `config.json`:
     "forward_primer": "GGAGAAAAGGAGACTTCGGCTACCCAG",
     "reverse_primer": "GCCGTTGTGCACCAGAGTAGAAGCTGA",
     "primer_source": "Wenzel et al. 2018 (PMID: 29520014)",
-    "expected_product_range": [1500, 15000]
+    "expected_product_range": [500, 15000]
 }
 ```
 
@@ -237,10 +237,10 @@ The primers are the core sequences from Wenzel et al. 2018 (PS2/PS3), used acros
 `expected_product_range` is optional. When set, the extracted amplicon length is validated:
 
 ```json
-"expected_product_range": [1500, 15000]
+"expected_product_range": [500, 15000]
 ```
 
-This means 1500 <= amplicon_length <= 6000 bp. Amplicons outside this range raise an error.
+This means 500 <= amplicon_length <= 15000 bp. Amplicons outside this range raise an error.
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -609,7 +609,7 @@ Parameters for PacBio amplicon read simulation with PCR length bias modeling.
     "forward_primer": "GGAGAAAAGGAGACTTCGGCTACCCAG",
     "reverse_primer": "GCCGTTGTGCACCAGAGTAGAAGCTGA",
     "primer_source": "Wenzel et al. 2018 (PMID: 29520014)",
-    "expected_product_range": [1500, 15000],
+    "expected_product_range": [500, 15000],
     "pcr_bias": {
       "preset": "default"
     }

--- a/tests/read_simulator/test_amplicon_extractor.py
+++ b/tests/read_simulator/test_amplicon_extractor.py
@@ -201,3 +201,94 @@ class TestAmpliconExtractor:
 
         result = extractor.extract(str(fasta), str(output))
         assert result.length > 0
+
+
+def _make_amplicon_fasta(tmp_path, muc1_primers, vntr_bp):
+    """Build a FASTA whose amplicon (primers + VNTR fill) is exactly vntr_bp + primer lengths.
+
+    The total amplicon size equals len(fwd) + vntr_bp + len(rev_rc).
+    """
+    from Bio.Seq import Seq
+
+    fwd = muc1_primers["forward"]
+    rev_rc = str(Seq(muc1_primers["reverse"]).reverse_complement())
+    # Fill with repeating bases to reach desired VNTR region size
+    fill = "ACGT" * ((vntr_bp // 4) + 1)
+    vntr_region = fill[:vntr_bp]
+    sequence = "N" * 50 + fwd + vntr_region + rev_rc + "N" * 50
+    fasta = tmp_path / f"hap_{vntr_bp}.fa"
+    fasta.write_text(f">hap1\n{sequence}\n")
+    expected_len = len(fwd) + vntr_bp + len(rev_rc)
+    return fasta, expected_len
+
+
+class TestAmpliconProductRangeBoundaries:
+    """Boundary tests for expected_product_range with the default [500, 15000] bounds.
+
+    Verifies that short VNTR alleles (<25 repeats, ~1200bp amplicon) are accepted
+    after lowering the minimum from 1500 to 500 (#91).
+    """
+
+    def test_1200bp_amplicon_passes_with_500_lower_bound(self, tmp_path, muc1_primers):
+        """A 20-repeat allele producing ~1200bp amplicon must pass with [500, 15000]."""
+        fasta, expected_len = _make_amplicon_fasta(tmp_path, muc1_primers, vntr_bp=1146)
+        # expected_len ≈ 1200 (1146 + 27 fwd + 27 rev_rc)
+        assert 1190 <= expected_len <= 1210
+        output = tmp_path / "amplicon.fa"
+
+        extractor = AmpliconExtractor(
+            forward_primer=muc1_primers["forward"],
+            reverse_primer=muc1_primers["reverse"],
+            expected_product_range=(500, 15000),
+        )
+
+        result = extractor.extract(str(fasta), str(output))
+        assert result.length == expected_len
+
+    def test_400bp_amplicon_rejected_below_500(self, tmp_path, muc1_primers):
+        """An amplicon of ~400bp must be rejected when minimum is 500."""
+        fasta, expected_len = _make_amplicon_fasta(tmp_path, muc1_primers, vntr_bp=346)
+        # expected_len ≈ 400 (346 + 27 + 27)
+        assert 390 <= expected_len <= 410
+        output = tmp_path / "amplicon.fa"
+
+        extractor = AmpliconExtractor(
+            forward_primer=muc1_primers["forward"],
+            reverse_primer=muc1_primers["reverse"],
+            expected_product_range=(500, 15000),
+        )
+
+        with pytest.raises(AmpliconExtractionError, match="outside expected"):
+            extractor.extract(str(fasta), str(output))
+
+    def test_3000bp_amplicon_passes(self, tmp_path, muc1_primers):
+        """A normal-sized 3000bp amplicon must pass with [500, 15000]."""
+        fasta, expected_len = _make_amplicon_fasta(tmp_path, muc1_primers, vntr_bp=2946)
+        # expected_len ≈ 3000
+        assert 2990 <= expected_len <= 3010
+        output = tmp_path / "amplicon.fa"
+
+        extractor = AmpliconExtractor(
+            forward_primer=muc1_primers["forward"],
+            reverse_primer=muc1_primers["reverse"],
+            expected_product_range=(500, 15000),
+        )
+
+        result = extractor.extract(str(fasta), str(output))
+        assert result.length == expected_len
+
+    def test_16000bp_amplicon_rejected_above_15000(self, tmp_path, muc1_primers):
+        """An amplicon of ~16000bp must be rejected when maximum is 15000."""
+        fasta, expected_len = _make_amplicon_fasta(tmp_path, muc1_primers, vntr_bp=15946)
+        # expected_len ≈ 16000
+        assert 15990 <= expected_len <= 16010
+        output = tmp_path / "amplicon.fa"
+
+        extractor = AmpliconExtractor(
+            forward_primer=muc1_primers["forward"],
+            reverse_primer=muc1_primers["reverse"],
+            expected_product_range=(500, 15000),
+        )
+
+        with pytest.raises(AmpliconExtractionError, match="outside expected"):
+            extractor.extract(str(fasta), str(output))


### PR DESCRIPTION
## Summary

- Lower `expected_product_range` minimum from 1500bp to 500bp in config.json
- Update documentation to reflect new range
- Add 4 boundary tests for product range validation

## Problem

Short VNTR alleles (<25 repeats) produce amplicons below 1500bp and are rejected by the amplicon extractor. This affects ~12% of simulated samples when sampling from the Vrbacka distribution with extended tails (min 20 repeats).

Fixes #91

## Test plan

- [x] 4 new boundary tests (1200bp passes, 400bp rejected, 3000bp passes, 16000bp rejected)
- [x] All 1430 existing tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)