### PR TITLE
chore: add CITATION.cff for repository citation support

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "MucOneUp"
+abstract: "A Python CLI tool for simulating MUC1 VNTR diploid references"
+authors:
+  - family-names: "Popp"
+    given-names: "Bernt"
+    orcid: "https://orcid.org/0000-0002-3679-1081"
+repository-code: "https://github.com/berntpopp/MucOneUp"
+url: "https://berntpopp.github.io/MucOneUp/"
+license: MIT
+version: "0.44.4"
+date-released: "2026-04-08"
+keywords:
+  - MUC1
+  - VNTR
+  - bioinformatics
+  - genomics
+  - simulation
+  - diploid reference
+  - ADTKD-MUC1


### PR DESCRIPTION
## Summary
- Adds `CITATION.cff` (CFF 1.2.0) so GitHub shows a "Cite this repository" button
- Includes author info, ORCID, current version, keywords, and project URLs
- Modeled after the open-pacmuci citation config

## Test plan
- [ ] CI actions pass
- [ ] Verify GitHub renders the citation widget on the repo page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)